### PR TITLE
check for process.platform !== 'browser' in Node.js detection

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -733,7 +733,7 @@
             }
           }
         }
-        else if (typeof context.process == 'object' && (data = context.process)) {
+        else if (typeof context.process == 'object' && context.process.platform !== 'browser' && (data = context.process)) {
           name = 'Node.js';
           arch = data.arch;
           os = data.platform;


### PR DESCRIPTION
Meteor.js 1.3 defines a global `process` object [1] on the window that fools platform.js into thinking it's running in node. The simplest way to fix this seems to be checking for the specific value of `process.platform` that meteor sets.
- [1] https://github.com/meteor/meteor/blob/release-1.3.2.4/packages/modules/process.js
